### PR TITLE
Release workflow based on JReleaser and Maven Central compliance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,53 @@
+# Inspired from https://foojay.io/today/how-to-release-a-java-module-with-jreleaser-to-maven-central-with-github-actions/
+name: Publish a new release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+      nextVersion:
+        description: 'Next version after release (-SNAPSHOT will be added automatically)'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Java setup
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: maven
+      - name: Run a build of the code base before release
+        run: mvn --batch-mode --no-transfer-progress clean install
+      - name: Set release version
+        run: mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ github.event.inputs.version }}
+      - name: Commit & Push changes
+        uses: actions-js/push@v1.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          message: "Releasing version ${{ github.event.inputs.version }}"
+      - name: Release with JReleaser
+        env:
+          JRELEASER_TAG_NAME: ${{ github.event.inputs.version }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+          JRELEASER_NEXUS2_USERNAME: ${{ secrets.JRELEASER_NEXUS2_USERNAME }}
+          JRELEASER_NEXUS2_PASSWORD: ${{ secrets.JRELEASER_NEXUS2_PASSWORD }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./release.sh
+      - name: Set the next release version
+        run: mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ github.event.inputs.nextVersion }}-SNAPSHOT
+      - name: Commit & Push changes
+        uses: actions-js/push@v1.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          message: "Setting version ${{ github.event.inputs.nextVersion }}-SNAPSHOT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,9 +26,9 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Run a build of the code base before release
-        run: mvn --batch-mode --no-transfer-progress clean install
+        run: ./mvnw --batch-mode --no-transfer-progress clean install
       - name: Set release version
-        run: mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ github.event.inputs.version }}
+        run: ./mvnw --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ github.event.inputs.version }}
       - name: Commit & Push changes
         uses: actions-js/push@v1.4
         with:
@@ -45,7 +45,7 @@ jobs:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./release.sh
       - name: Set the next release version
-        run: mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ github.event.inputs.nextVersion }}-SNAPSHOT
+        run: ./mvnw --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ github.event.inputs.nextVersion }}-SNAPSHOT
       - name: Commit & Push changes
         uses: actions-js/push@v1.4
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,40 @@
   <artifactId>runtimes-agent</artifactId>
   <version>1.0.0-SNAPSHOT</version>
 
+  <name>Red Hat Insights Java Agent</name>
+  <description>Red Hat Insights Java Agent</description>
+  <url>https://github.com/RedHatInsights/insights-java-agent</url>
+  <inceptionYear>2023</inceptionYear>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Benjamin Evans</name>
+      <email>beevans@redhat.com</email>
+      <organization>Red Hat</organization>
+      <organizationUrl>https://www.redhat.com/</organizationUrl>
+    </developer>
+    <developer>
+      <id>ebaron</id>
+      <name>Elliott Baron</name>
+      <email>ebaron@redhat.com</email>
+      <organization>Red Hat</organization>
+      <organizationUrl>https://www.redhat.com/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/RedHatInsights/insights-java-agent.git</connection>
+    <developerConnection>scm:git:ssh://github.com:RedHatInsights/insights-java-agent.git</developerConnection>
+    <url>http://github.com/RedHatInsights/insights-java-agent/tree/main</url>
+  </scm>
+
   <properties>
     <!--    <maven.compiler.release>8</maven.compiler.release>-->
     <maven.compiler.source>8</maven.compiler.source>
@@ -38,6 +72,9 @@
     <maven-install-plugin.version>3.1.0</maven-install-plugin.version>
     <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
     <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
+    <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+    <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
+    <jreleaser-maven-plugin.version>1.9.0</jreleaser-maven-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -350,6 +387,7 @@
               <descriptorRefs>
                 <descriptorRef>jar-with-dependencies</descriptorRef>
               </descriptorRefs>
+              <attach>true</attach>
             </configuration>
           </execution>
         </executions>
@@ -425,5 +463,86 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jreleaser</groupId>
+            <artifactId>jreleaser-maven-plugin</artifactId>
+            <version>${jreleaser-maven-plugin.version}</version>
+            <inherited>false</inherited>
+            <configuration>
+              <jreleaser>
+                <signing>
+                  <active>ALWAYS</active>
+                  <armored>true</armored>
+                </signing>
+                <deploy>
+                  <maven>
+                    <nexus2>
+                      <maven-central>
+                        <active>ALWAYS</active>
+                        <url>https://oss.sonatype.org/service/local</url>
+                        <snapshotUrl>https://oss.sonatype.org/content/repositories/snapshots/</snapshotUrl>
+                        <closeRepository>true</closeRepository>
+                        <releaseRepository>true</releaseRepository>
+                        <stagingRepositories>target/staging-deploy</stagingRepositories>
+                      </maven-central>
+                    </nexus2>
+                  </maven>
+                </deploy>
+              </jreleaser>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>publication</id>
+      <properties>
+        <altDeploymentRepository>local::file:./target/staging-deploy</altDeploymentRepository>
+      </properties>
+      <build>
+        <defaultGoal>deploy</defaultGoal>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${maven-javadoc-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <attach>true</attach>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${maven-source-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+                <configuration>
+                  <attach>true</attach>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
   </profiles>
 </project>

--- a/release.sh
+++ b/release.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 IFS=$'\n\t'
 
 echo "📦 Staging artifacts..."
-mvn --batch-mode --no-transfer-progress -Ppublication -DskipTests=true -Dskip.spotless=true
+./mvnw --batch-mode --no-transfer-progress -Ppublication -DskipTests=true -Dskip.spotless=true
 
 echo "🚀 Releasing..."
-mvn --batch-mode --no-transfer-progress -Prelease jreleaser:full-release
+./mvnw --batch-mode --no-transfer-progress -Prelease jreleaser:full-release
 
 echo "🎉 Done!"

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+echo "📦 Staging artifacts..."
+mvn --batch-mode --no-transfer-progress -Ppublication -DskipTests=true -Dskip.spotless=true
+
+echo "🚀 Releasing..."
+mvn --batch-mode --no-transfer-progress -Prelease jreleaser:full-release
+
+echo "🎉 Done!"


### PR DESCRIPTION
The proposed workflow allows for 1-clic releases from GitHub Action.

### Overview

This is a port of the workflow from the Java Insights Client with a few adaptations to this project.

This also includes compliance with Maven Central rules (e.g., POM, attached artifacts, etc).

### Required secrets

This workflow assumes that the following secrets exist at the repository level:

- `JRELEASER_NEXUS2_USERNAME` / `JRELEASER_NEXUS2_PASSWORD` are the [Sonatype OSS](https://issues.sonatype.org/) credentials to release to Maven Central
- `JRELEASER_GPG_PUBLIC_KEY` / `JRELEASER_GPG_SECRET_KEY` / `JRELEASER_GPG_PASSPHRASE` are GnuPG key data
  - the GnuPG key **must** have been published to some public key server (e.g., https://keys.openpgp.org/)
  - the public key must be `base64`-encoded: `gpg --export <id> | base64`
  - the private key must also be `base64`-encoded: `gpg --export-secret-keys <key id> | base64`

### Resilience

Publishing to Maven Central is not always a smooth drive (e.g., bad gateway failures).

This workflow is quite resilient.
In case of failure one will have no release but just an additional commit in `main` that set the release version.
Simply revert that commit and start the release again.

### How to test locally

It is a good idea to check that the secrets are correct before attempting to do a first release candidate.

Simply export all secrets as environment variables in your current shell.

Also add one for your GitHub personal access token: `export JRELEASER_GITHUB_TOKEN=$(gh auth token)` (see https://cli.github.com/)

You can then do a dry run:

```
$ mvn clean
$ mvn --no-transfer-progress -Ppublication -DskipTests=true -Dskip.spotless=true
$ mvn --no-transfer-progress -Prelease jreleaser:full-release -Djreleaser.dry.run=true
```

This won't create a release, but it should succeed in preparing artifacts, signing them and doing checks against the repository.