### PR TITLE
Use SLF4J, avoid interfering with application logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>
     <apache.httpmime.version>4.5.14</apache.httpmime.version>
+    <org.slf4j.version>2.0.7</org.slf4j.version>
 
     <!-- Test libraries versions -->
     <junit.version>5.9.2</junit.version>
@@ -105,6 +106,21 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpmime</artifactId>
         <version>${apache.httpmime.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${org.slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${org.slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${org.slf4j.version}</version>
       </dependency>
 
       <!--      Tools jar -->
@@ -180,6 +196,25 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <!-- TODO remove this SLF4J provider. We should just depend on what SLF4J provider is available in the attached
+        application's classpath at runtime, if any. -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
@@ -331,12 +366,23 @@
                   <pattern>com.redhat.insights</pattern>
                   <shadedPattern>${shade.prefix}</shadedPattern>
                   <excludes>
-                    <exclude>com.redhat.insights.agent.*</exclude>
+                    <exclude>com.redhat.insights.agent.**</exclude>
                   </excludes>
                 </relocation>
                 <relocation>
                   <pattern>org.apache</pattern>
                   <shadedPattern>${shade.prefix}.org.apache</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.slf4j</pattern>
+                  <shadedPattern>${shade.prefix}.org.slf4j</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>java.util.logging.Logger</pattern>
+                  <shadedPattern>${shade.prefix}.ShadeLogger</shadedPattern>
+                  <excludes>
+                    <exclude>${shade.prefix}.ShadeLogger</exclude>
+                  </excludes>
                 </relocation>
                 <relocation>
                   <pattern>org.wildfly.common</pattern>

--- a/src/main/java/com/redhat/insights/agent/AgentBasicReport.java
+++ b/src/main/java/com/redhat/insights/agent/AgentBasicReport.java
@@ -10,19 +10,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class AgentBasicReport extends AbstractTopLevelReportBase {
+  private static final InsightsLogger logger = new SLF4JLogger(AgentBasicReport.class);
+
   private AgentBasicReport(
-      InsightsLogger logger,
-      InsightsConfiguration config,
-      Map<String, InsightsSubreport> subReports) {
+      InsightsConfiguration config, Map<String, InsightsSubreport> subReports) {
     super(logger, config, subReports);
   }
 
-  public static AgentBasicReport of(InsightsLogger logger, InsightsConfiguration configuration) {
+  public static AgentBasicReport of(InsightsConfiguration configuration) {
     Map<String, InsightsSubreport> reports = new HashMap<>();
     ClasspathJarInfoSubreport jarsReport = new ClasspathJarInfoSubreport(logger);
     reports.put("jars", jarsReport);
-    reports.put("details", AgentSubreport.of(logger, jarsReport));
-    return new AgentBasicReport(logger, configuration, reports);
+    reports.put("details", AgentSubreport.of(jarsReport));
+    return new AgentBasicReport(configuration, reports);
   }
 
   @Override

--- a/src/main/java/com/redhat/insights/agent/AgentSubreport.java
+++ b/src/main/java/com/redhat/insights/agent/AgentSubreport.java
@@ -15,10 +15,11 @@ import java.util.Map;
 import java.util.function.Function;
 
 public class AgentSubreport implements InsightsSubreport {
+  private static final InsightsLogger logger = new SLF4JLogger(AgentSubreport.class);
+
   private static final Class<?>[] EMPTY_CLASS_ARRAY = new Class[0];
   private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
 
-  private final InsightsLogger logger;
   private final ClasspathJarInfoSubreport jarsReport;
 
   private String guessedWorkload = "Unidentified";
@@ -33,13 +34,12 @@ public class AgentSubreport implements InsightsSubreport {
     activeGuesses.put("org.apache.catalina.Server", AgentSubreport::fingerprintTomcat);
   }
 
-  private AgentSubreport(InsightsLogger logger, ClasspathJarInfoSubreport jarsReport) {
-    this.logger = logger;
+  private AgentSubreport(ClasspathJarInfoSubreport jarsReport) {
     this.jarsReport = jarsReport;
   }
 
-  public static InsightsSubreport of(InsightsLogger logger, ClasspathJarInfoSubreport jarsReport) {
-    return new AgentSubreport(logger, jarsReport);
+  public static InsightsSubreport of(ClasspathJarInfoSubreport jarsReport) {
+    return new AgentSubreport(jarsReport);
   }
 
   @Override

--- a/src/main/java/com/redhat/insights/agent/ClassNoticer.java
+++ b/src/main/java/com/redhat/insights/agent/ClassNoticer.java
@@ -15,7 +15,8 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 
 public final class ClassNoticer implements ClassFileTransformer {
-  private final InsightsLogger logger;
+  private static final InsightsLogger logger = new SLF4JLogger(ClassNoticer.class);
+
   private final BlockingQueue<JarInfo> jarsToSend;
   private final JarAnalyzer analyzer;
 
@@ -24,8 +25,7 @@ public final class ClassNoticer implements ClassFileTransformer {
   private final Set<String> seenJarHashes = new HashSet<>();
   private final Set<String> seenUrls = new HashSet<>();
 
-  public ClassNoticer(InsightsLogger logger, BlockingQueue<JarInfo> jarsToSend) {
-    this.logger = logger;
+  public ClassNoticer(BlockingQueue<JarInfo> jarsToSend) {
     this.jarsToSend = jarsToSend;
     this.analyzer = new JarAnalyzer(logger, true);
   }

--- a/src/main/java/com/redhat/insights/agent/InsightsAgentHttpClient.java
+++ b/src/main/java/com/redhat/insights/agent/InsightsAgentHttpClient.java
@@ -28,17 +28,14 @@ import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
 import org.apache.http.util.EntityUtils;
 
 public final class InsightsAgentHttpClient implements InsightsHttpClient {
-  private final InsightsLogger logger;
+  private static final InsightsLogger logger = new SLF4JLogger(InsightsAgentHttpClient.class);
   private static final ContentType GENERAL_CONTENT_TYPE = ContentType.create(GENERAL_MIME_TYPE);
   private final Supplier<SSLContext> sslContextSupplier;
   private final InsightsConfiguration configuration;
   private final boolean useMTLS;
 
   public InsightsAgentHttpClient(
-      InsightsLogger logger,
-      InsightsConfiguration configuration,
-      Supplier<SSLContext> sslContextSupplier) {
-    this.logger = logger;
+      InsightsConfiguration configuration, Supplier<SSLContext> sslContextSupplier) {
     this.configuration = configuration;
     this.sslContextSupplier = sslContextSupplier;
     this.useMTLS = !configuration.getMaybeAuthToken().isPresent();

--- a/src/main/java/com/redhat/insights/agent/SLF4JLogger.java
+++ b/src/main/java/com/redhat/insights/agent/SLF4JLogger.java
@@ -1,0 +1,50 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.insights.agent;
+
+import com.redhat.insights.logging.InsightsLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SLF4JLogger implements InsightsLogger {
+
+  private final Logger delegate;
+
+  public SLF4JLogger(Class<?> clazz) {
+    this.delegate = LoggerFactory.getLogger(clazz);
+  }
+
+  @Override
+  public void debug(String message) {
+    delegate.debug(message);
+  }
+
+  @Override
+  public void debug(String message, Throwable err) {
+    delegate.debug(message, err);
+  }
+
+  @Override
+  public void error(String message) {
+    delegate.error(message);
+  }
+
+  @Override
+  public void error(String message, Throwable err) {
+    delegate.error(message, err);
+  }
+
+  @Override
+  public void info(String message) {
+    delegate.info(message);
+  }
+
+  @Override
+  public void warning(String message) {
+    delegate.warn(message);
+  }
+
+  @Override
+  public void warning(String message, Throwable err) {
+    delegate.warn(message, err);
+  }
+}

--- a/src/main/java/com/redhat/insights/agent/shaded/ShadeLogger.java
+++ b/src/main/java/com/redhat/insights/agent/shaded/ShadeLogger.java
@@ -1,0 +1,89 @@
+/* Copyright (C) Red Hat 2023 */
+package com.redhat.insights.agent.shaded;
+
+import java.util.ResourceBundle;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+// Maven Shade plugin rewrites java.util.logging.Logger classes to reference this one instead.
+// This is part of the encapsulation of the Agent's logging to separate it from the attached
+// application's logging.
+public class ShadeLogger {
+
+  public static ShadeLogger getLogger(String name) {
+    return new ShadeLogger();
+  }
+
+  public static ShadeLogger getLogger(String name, String resourceBundleName) {
+    return new ShadeLogger();
+  }
+
+  public static ShadeLogger getAnonymousLogger() {
+    return new ShadeLogger();
+  }
+
+  public static ShadeLogger getAnonymousLogger(String resourceBundleName) {
+    return new ShadeLogger();
+  }
+
+  public String getName() {
+    return "";
+  }
+
+  public void log(LogRecord record) {}
+
+  public void log(Level level, String msg) {}
+
+  public void log(Level level, String msg, Object arg1) {}
+
+  public void log(Level level, String msg, Object[] args) {}
+
+  public void log(Level level, String msg, Throwable t) {}
+
+  public void logp(Level level, String klazz, String mtd, String msg) {}
+
+  public void logp(Level level, String klazz, String mtd, String msg, Object arg1) {}
+
+  public void logp(Level level, String klazz, String mtd, String msg, Object[] args) {}
+
+  public void logp(Level level, String klazz, String mtd, String msg, Throwable t) {}
+
+  public void logrb(Level level, String klazz, String mtd, String bundle, String msg) {}
+
+  public void logrb(
+      Level level, String klazz, String mtd, String bundle, String msg, Object arg1) {}
+
+  public void logrb(
+      Level level, String klazz, String mtd, String bundle, String msg, Object[] args) {}
+
+  public void logrb(
+      Level level, String klazz, String mtd, ResourceBundle bundle, String msg, Object... args) {}
+
+  public void logrb(
+      Level level, String klazz, String mtd, String bundle, String msg, Throwable t) {}
+
+  public void logrb(
+      Level level, String klazz, String mtd, ResourceBundle bundle, String msg, Throwable t) {}
+
+  public void severe(String msg) {}
+
+  public void warning(String msg) {}
+
+  public void info(String msg) {}
+
+  public void config(String msg) {}
+
+  public void fine(String msg) {}
+
+  public void finer(String msg) {}
+
+  public void finest(String msg) {}
+
+  public void throwing(String klazz, String mtd, Throwable t) {}
+
+  public void setLevel(Level newLevel) throws SecurityException {}
+
+  public boolean isLoggable(Level level) {
+    return false;
+  }
+}

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -1,0 +1,4 @@
+# SLF4J's SimpleLogger configuration file - https://www.slf4j.org/api/org/slf4j/simple/SimpleLogger.html
+# prepend config property names with the pom.xml ${shade.prefix} due to bytecode relocation
+${shade.prefix}.org.slf4j.simpleLogger.showDateTime=true
+${shade.prefix}.org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z

--- a/src/test/java/com/redhat/insights/agent/ClassNoticerTest.java
+++ b/src/test/java/com/redhat/insights/agent/ClassNoticerTest.java
@@ -34,14 +34,14 @@ public class ClassNoticerTest {
 
     InsightsLogger logger = new NoopInsightsLogger();
     BlockingQueue<JarInfo> jarsToSend = new LinkedBlockingQueue<>();
-    ClassNoticer noticer = new ClassNoticer(logger, jarsToSend);
+    ClassNoticer noticer = new ClassNoticer(jarsToSend);
     instrumentation.addTransformer(noticer);
 
     InsightsConfiguration mockConfig =
         MockInsightsConfiguration.of("test_app", false, Duration.ofDays(1), Duration.ofSeconds(5));
     InsightsHttpClient mockHttpClient = Mockito.mock(InsightsHttpClient.class);
     Mockito.when(mockHttpClient.isReadyToSend()).thenReturn(true);
-    InsightsReport report = AgentBasicReport.of(logger, mockConfig);
+    InsightsReport report = AgentBasicReport.of(mockConfig);
     InsightsScheduler scheduler = InsightsCustomScheduledExecutor.of(logger, mockConfig);
 
     InsightsReportController controller =


### PR DESCRIPTION
When testing with EAP, we found a conflict with our JUL logging and EAP's logging that prevented it from starting. This PR ports over the logging setup from https://github.com/cryostatio/cryostat-agent that avoids this problem using an SLF4J configuration that avoids conflicts with the host application's logging.

This implementation was originally done by @andrewazores