### PR TITLE
Fix token detection

### DIFF
--- a/src/main/java/com/redhat/insights/agent/AgentMain.java
+++ b/src/main/java/com/redhat/insights/agent/AgentMain.java
@@ -159,7 +159,7 @@ public final class AgentMain {
   }
 
   private static boolean shouldLookForCerts(AgentConfiguration config) {
-    boolean hasToken = !config.getMaybeAuthToken().isPresent();
+    boolean hasToken = config.getMaybeAuthToken().isPresent();
     return !hasToken && !config.isDebug() && !config.isFileOnly();
   }
 


### PR DESCRIPTION
When parsing command line arguments, the logic is negated when checking for a token. When a token is provided, the agent will attempt to look for a key/cert and fail to start.