### PR TITLE
Filter shade.prefix in simplelogger.properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,13 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <filtering>true</filtering>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+
     <pluginManagement>
       <plugins>
         <plugin>


### PR DESCRIPTION
I noticed the simplelogger.properties file still contained `${shade.prefix}` which should be substituted with the corresponding Maven property. This PR turns on resource filtering to do this.