### PR TITLE
Fix default base_url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The available key-value pairs are:
 | `cert`       | `/etc/pki/consumer/cert.pem`            | Certificate path file                              |
 | `key`        | `/etc/pki/consumer/key.pem`             | Certificate key file                               |
 | `token`      | (empty)                                 | Authentication token for token-based auth, if used |
-| `base_url`   | `https://cert.console.stage.redhat.com` | Server endpoint URL                                |
+| `base_url`   | `https://cert.console.redhat.com`       | Server endpoint URL                                |
 | `uri`        | `/api/ingress/v1/upload`                | Request URI at the server endpoint                 |
 | `proxy`      | (empty)                                 | Proxy host, if any                                 |
 | `proxy_port` | (empty)                                 | Proxy port, if any                                 |


### PR DESCRIPTION
Default base_url in not to stage. If no value present it falls bach to InsightsConfiguration.DEFAULT_UPLOAD_BASE_URL which is "https://cert.console.redhat.com"