### PR TITLE
Use system property to configure debug logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>
     <apache.httpmime.version>4.5.14</apache.httpmime.version>
-    <org.slf4j.version>2.0.12</org.slf4j.version>
+    <org.slf4j.version>2.0.7</org.slf4j.version>
 
     <!-- Test libraries versions -->
     <junit.version>5.9.2</junit.version>

--- a/src/main/java/com/redhat/insights/agent/AgentLogger.java
+++ b/src/main/java/com/redhat/insights/agent/AgentLogger.java
@@ -23,15 +23,9 @@ public class AgentLogger implements InsightsLogger {
     return instance;
   }
 
-  static class DebugSimpleLogger extends SimpleLogger {
-    public DebugSimpleLogger() {
-      super("com.redhat.insights.agent.AgentLogger");
-      currentLogLevel = SimpleLogger.LOG_LEVEL_DEBUG;
-    }
-  }
-
   public void setDebugDelegate() {
-    this.delegate = new DebugSimpleLogger();
+    System.setProperty(SimpleLogger.LOG_KEY_PREFIX + "com.redhat.insights.agent", "debug");
+    this.delegate = LoggerFactory.getLogger("com.redhat.insights.agent.AgentLogger");
   }
 
   @Override


### PR DESCRIPTION
This downgrades slf4j to help with downstream builds, and uses a System property to set the log level of the debug logger. This is necessary because the SimpleLogger constructor is not public in SLF4J 2.0.7.

It should be possible to set the log level in the simplelogger.properties file, but I wasn't able to get this working with EAP. Their classloader was unable to locate the simplelogger.properties file when SLF4J created the logger.

I tested the following scenarios:

1. EAP 7.4.0 with shaded jar and `debug=true`
    ```
    MODULE_OPTS='-javaagent:runtimes-agent-0.9.5-SNAPSHOT-shaded.jar=name=logging-test\;token=foo\;debug=true\;defer=false\;is_ocp=true' ./bin/standalone.sh
    ...debug output...
    ```

2. EAP 7.4.0 with shaded jar and without `debug=true`
    ```
    MODULE_OPTS='-javaagent:runtimes-agent-0.9.5-SNAPSHOT-shaded.jar=name=logging-test\;token=foo\;defer=false\;is_ocp=true' ./bin/standalone.sh
    ...no debug output...
    ```

3. EAP 7.4.0 with uber jar and `debug=true`
    ```
    MODULE_OPTS='-javaagent:runtimes-agent-0.9.5-SNAPSHOT-jar-with-dependencies.jar=name=logging-test\;token=foo\;debug=true\;defer=false\;is_ocp=true' ./bin/standalone.sh
    ...debug output...
    ```

4. EAP 7.4.0 with uber jar and without `debug=true`
    ```
    MODULE_OPTS='-javaagent:runtimes-agent-0.9.5-SNAPSHOT-jar-with-dependencies.jar=name=logging-test\;token=foo\;defer=false\;is_ocp=true' ./bin/standalone.sh
    ...no debug output...
    ```

5. Quarkus 3.7 quickstart with shaded jar and `debug=true`
    ```
    java -javaagent:runtimes-agent-0.9.5-SNAPSHOT-shaded.jar=name=logging-test\;token=foo\;debug=true\;defer=false\;is_ocp=true -jar target/quarkus-app/quarkus-run.jar 
    ...debug output...
    ```

6. Quarkus 3.7 quickstart with shaded jar and without `debug=true`
    ```
    java -javaagent:runtimes-agent-0.9.5-SNAPSHOT-shaded.jar=name=logging-test\;token=foo\;defer=false\;is_ocp=true -jar target/quarkus-app/quarkus-run.jar
    ...no debug output...
    ```

7. Quarkus 3.7 quickstart with uber jar and `debug=true`
    ```
    java -javaagent:runtimes-agent-0.9.5-SNAPSHOT-jar-with-dependencies.jar=name=logging-test\;token=foo\;debug=true\;defer=false\;is_ocp=true -jar target/quarkus-app/quarkus-run.jar 
    ...debug output...
    ```

8. Quarkus 3.7 quickstart with uber jar and without `debug=true`
    ```
    java -javaagent:runtimes-agent-0.9.5-SNAPSHOT-jar-with-dependencies.jar=name=logging-test\;token=foo\;defer=false\;is_ocp=true -jar target/quarkus-app/quarkus-run.jar 
    ...no debug output...
    ```