### PR TITLE
Wait for jboss-modules to set module.path property

### DIFF
--- a/src/main/java/com/redhat/insights/agent/AgentSubreport.java
+++ b/src/main/java/com/redhat/insights/agent/AgentSubreport.java
@@ -142,13 +142,8 @@ public class AgentSubreport implements InsightsSubreport {
               .getDeclaredMethod("getPrettyVersionString", EMPTY_CLASS_ARRAY)
               .invoke(productConfig, EMPTY_OBJECT_ARRAY);
 
-    } catch (NoSuchMethodException
-        | SecurityException
-        | ClassNotFoundException
-        | IllegalAccessException
-        | IllegalArgumentException
-        | InvocationTargetException ex) {
-      // ignore
+    } catch (Exception ex) {
+      logger.debug("Ignoring exception during JBoss probe", ex);
     }
     return "Unknown EAP / Wildfly - possibly misconfigured";
   }


### PR DESCRIPTION
This PR modifies the `fingerprintJBoss` method to wait, with timeout, for the `module.path` system property to be set. Attempting to get the boot module loader before this results in a broken module loader. I've done some refactoring to reuse the same logic used to get the `jboss.home` property.

This also includes @kittylyst's commit to catch and log any exceptions thrown during the JBoss fingerprinting process.