### PR TITLE
Update runtimes client to 2.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <skip.spotless>false</skip.spotless>
 
     <!-- Core dependencies versions -->
-    <runtimes.java.api.version>2.0.3</runtimes.java.api.version>
+    <runtimes.java.api.version>2.0.4</runtimes.java.api.version>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <apache.httpcore.version>4.4.16</apache.httpcore.version>
     <apache.httpmime.version>4.5.14</apache.httpmime.version>
@@ -70,7 +70,7 @@
     <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-    <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <maven-install-plugin.version>3.1.0</maven-install-plugin.version>
     <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
     <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>


### PR DESCRIPTION
Updates the runtimes-java-api version to 2.0.4. This also requires a shade plugin bump to resolve the following build error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.5.1:shade (shade-jar-with-dependencies) on project runtimes-agent: Error creating shaded jar: Problem shading JAR /home/ebaron/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.18.0/jackson-core-2.18.0.jar entry META-INF/versions/22/com/fasterxml/jackson/core/internal/shaded/fdp/v2_18_0/FastDoubleSwar.class: java.lang.IllegalArgumentException: Unsupported class file major version 66 -> [Help 1]
```