### PR TITLE
Remove -v parameter from egg script jinfo starter

### DIFF
--- a/src/main/python/insights_jvm.py
+++ b/src/main/python/insights_jvm.py
@@ -323,7 +323,7 @@ def run_jinfo(jinfo_path, pid):
     """
     try:
         # Run jinfo with verbose flag to get more information
-        result = subprocess.run([jinfo_path, '-v', str(pid)],
+        result = subprocess.run([jinfo_path, str(pid)],
                               capture_output=True,
                               text=True,
                               timeout=10)


### PR DESCRIPTION
AFAIK `-v` is not a valid parameter for jinfo (at least it is not documented) and it causes the egg script to fail for JAVA 8.