### PR TITLE
Add environment variables for agent configuration

### DIFF
--- a/src/main/java/com/redhat/insights/agent/AgentConfiguration.java
+++ b/src/main/java/com/redhat/insights/agent/AgentConfiguration.java
@@ -1,4 +1,4 @@
-/* Copyright (C) Red Hat 2023-2024 */
+/* Copyright (C) Red Hat 2023-2025 */
 package com.redhat.insights.agent;
 
 import com.redhat.insights.config.EnvAndSysPropsInsightsConfiguration;
@@ -26,6 +26,10 @@ public final class AgentConfiguration extends EnvAndSysPropsInsightsConfiguratio
   static final String AGENT_ARG_SHOULD_DEFER = "should_defer";
   static final String AGENT_ARG_POD_NAME = "pod_name";
   static final String AGENT_ARG_POD_NAMESPACE = "pod_namespace";
+
+  static final String ENV_POD_NAME = "RHT_INSIGHTS_JAVA_AGENT_POD_NAME";
+  static final String ENV_POD_NAMESPACE = "RHT_INSIGHTS_JAVA_AGENT_POD_NAMESPACE";
+  static final String ENV_DEBUG = "RHT_INSIGHTS_JAVA_AGENT_DEBUG";
 
   static final String PROPERTY_NOT_GIVEN_DEFAULT = "[NONE]";
   private final Map<String, String> args;
@@ -130,7 +134,11 @@ public final class AgentConfiguration extends EnvAndSysPropsInsightsConfiguratio
   // Agent specific configuration
 
   public boolean isDebug() {
-    return TRUE.equalsIgnoreCase(args.getOrDefault(AGENT_ARG_DEBUG, FALSE));
+    String value = lookup(ENV_DEBUG);
+    if (value == null) {
+      value = args.getOrDefault(AGENT_ARG_DEBUG, FALSE);
+    }
+    return TRUE.equalsIgnoreCase(value);
   }
 
   // See https://issues.redhat.com/browse/MWTELE-93 for more information
@@ -149,10 +157,26 @@ public final class AgentConfiguration extends EnvAndSysPropsInsightsConfiguratio
   }
 
   public String getPodNamespace() {
+    String value = lookup(ENV_POD_NAMESPACE);
+    if (value != null) {
+      return value;
+    }
     return args.getOrDefault(AGENT_ARG_POD_NAMESPACE, PROPERTY_NOT_GIVEN_DEFAULT);
   }
 
   public String getPodName() {
+    String value = lookup(ENV_POD_NAME);
+    if (value != null) {
+      return value;
+    }
     return args.getOrDefault(AGENT_ARG_POD_NAME, PROPERTY_NOT_GIVEN_DEFAULT);
+  }
+
+  private String lookup(String env) {
+    String value = System.getenv(env);
+    if (value == null) {
+      value = System.getProperty(env.toLowerCase().replace('_', '.'));
+    }
+    return value;
   }
 }

--- a/src/main/java/com/redhat/insights/agent/AgentMain.java
+++ b/src/main/java/com/redhat/insights/agent/AgentMain.java
@@ -1,4 +1,4 @@
-/* Copyright (C) Red Hat 2023-2024 */
+/* Copyright (C) Red Hat 2023-2025 */
 package com.redhat.insights.agent;
 
 import com.redhat.insights.InsightsException;
@@ -52,10 +52,6 @@ public final class AgentMain {
       loaded = true;
     }
 
-    if (agentArgs == null || agentArgs.isEmpty()) {
-      logger.error("Unable to start Red Hat Insights agent: Need config arguments");
-      return;
-    }
     Optional<AgentConfiguration> oArgs = parseArgs(agentArgs);
     if (!oArgs.isPresent()) {
       return;
@@ -130,15 +126,17 @@ public final class AgentMain {
    */
   static Optional<AgentConfiguration> parseArgs(String agentArgs) {
     Map<String, String> out = new HashMap<>();
-    for (String pair : agentArgs.split(";")) {
-      String[] kv = pair.split("=");
-      if (kv.length != 2) {
-        logger.error(
-            "Unable to start Red Hat Insights agent: Malformed config arguments (should be"
-                + " key-value pairs)");
-        return Optional.empty();
+    if (agentArgs != null && !agentArgs.isEmpty()) {
+      for (String pair : agentArgs.split(";")) {
+        String[] kv = pair.split("=");
+        if (kv.length != 2) {
+          logger.error(
+              "Unable to start Red Hat Insights agent: Malformed config arguments (should be"
+                  + " key-value pairs)");
+          return Optional.empty();
+        }
+        out.put(kv[0], kv[1]);
       }
-      out.put(kv[0], kv[1]);
     }
     AgentConfiguration config = new AgentConfiguration(out);
 


### PR DESCRIPTION
While Insights Java Client configuration parameters have environment variable and system property counterparts, the agent-specific parameters do not. This PR allows the pod name/namespace and debug parameters to be set using environment variables as well.

This is helpful for the operator v2 work since the semicolon separators in the agent arguments were causing issues with the shell scripts in certain container entrypoints.